### PR TITLE
Fixes critical error when parsing stored errors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* The JSON encoded report in the system report view was decoded twice: once when retrieved, and once when displayed which caused a fatal error. This has been corrected to ensure the report is only decoded once, only when it is about to be displayed.
+
 ------------------
 ## [1.0.0] - 2025-05-28
 

--- a/src/Views/Admin/status-report.php
+++ b/src/Views/Admin/status-report.php
@@ -3,7 +3,7 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-$report         = json_decode( get_option( 'krokedil_support_' . $id, '[]' ), true );
+$report         = get_option( 'krokedil_support_' . $id );
 $settings_title = "$name plugin settings";
 
 ?>
@@ -30,7 +30,7 @@ $settings_title = "$name plugin settings";
 					<td><?php echo esc_html( $log['timestamp'] ); ?></td>
 					<td class="help"></td>
 					<td><?php echo esc_html( $log['response']['code'] ); ?></td>
-					<td><?php echo esc_html( trim( wp_json_encode( $log['response']['message'] ), '"' ) ); ?></td>
+					<td><?php echo esc_html( trim( $log['response']['message'], '"' ) ); ?></td>
 					<td><?php echo esc_html( trim( empty( $log['response']['extra'] ) ? '' : wp_json_encode( $log['response']['extra'] ), '"' ) ); ?></td>
 				</tr>
 			<?php endforeach; ?>

--- a/src/Views/Admin/status-report.php
+++ b/src/Views/Admin/status-report.php
@@ -19,7 +19,6 @@ $settings_title = "$name plugin settings";
 			<td class="help"></td>
 			<td><strong><?php esc_html_e( 'Code', 'krokedil-support' ); ?></strong></td>
 			<td><strong><?php esc_html_e( 'Message', 'krokedil-support' ); ?></strong></td>
-			<td><strong><?php esc_html_e( 'Details', 'krokedil-support' ); ?></strong></td>
 		</tr>
 	</thead>
 	<tbody>

--- a/src/Views/Admin/status-report.php
+++ b/src/Views/Admin/status-report.php
@@ -18,7 +18,7 @@ $settings_title = "$name plugin settings";
 			<td><strong><?php esc_html_e( 'Timestamp', 'krokedil-support' ); ?></strong></td>
 			<td class="help"></td>
 			<td><strong><?php esc_html_e( 'Code', 'krokedil-support' ); ?></strong></td>
-			<td><strong><?php esc_html_e( 'Message', 'krokedil-support' ); ?></strong></td>
+			<td colspan="6"><strong><?php esc_html_e( 'Message', 'krokedil-support' ); ?></strong></td>
 		</tr>
 	</thead>
 	<tbody>


### PR DESCRIPTION
Due to a double JSON-decoding, the system report fails to produce the view for error messages.

- delays decoding until needed, and only does it once.

https://app.clickup.com/t/86997n8wp