### PR TITLE
Explictly set autoloading to false

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,11 +2,13 @@
 
 All notable changes of krokedil/support are documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://kepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+* Explicitly disabled autoloading the system report option to prevent it from being loaded on every request, as it is only needed when issuing a request, and viewing the system report.
+ 
 ------------------
 ## [1.0.2] - 2025-10-08
 

--- a/src/SystemReport.php
+++ b/src/SystemReport.php
@@ -239,7 +239,7 @@ class SystemReport {
 			),
 		);
 
-		update_option( 'krokedil_support_' . $this->id, wp_json_encode( $logs ) );
+		update_option( 'krokedil_support_' . $this->id, wp_json_encode( $logs ), false );
 		return $response;
 	}
 
@@ -257,6 +257,6 @@ class SystemReport {
 				unset( $reports[ $key ] );
 			}
 		}
-		update_option( 'krokedil_support_' . $this->id, wp_json_encode( $reports ) );
+		update_option( 'krokedil_support_' . $this->id, wp_json_encode( $reports ), false );
 	}
 }


### PR DESCRIPTION
Per WP [update_option](https://developer.wordpress.org/reference/functions/update_option/) documentation, unless explicitly set, autoloading might be enabled. I couldn't recreate this in my local environment, but a merchant could which indicate that there are factors that WP takes into consideration when it is set to "auto" (default for `autoload=null`).

The system report JSON data don't need to be autoloaded on every page load. This PR explicitly sets it to false.

https://app.clickup.com/t/869cnpu6j