### PR TITLE
Version 1.0.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://kepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+* The $form_field variable can sometimes be missing keys that are available in the $setting array when "MU"-plugins are used. Added a check to ensure that the keys exist in both arrays before attempting to access them, preventing potential undefined key errors.
  
 ------------------
 ## [1.0.3] - 2026-03-30

--- a/changelog.md
+++ b/changelog.md
@@ -6,11 +6,15 @@ The format is based on [Keep a Changelog](https://kepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+
+------------------
+## [1.0.4] - 2026-03-30
+
 ### Fixed
 
 * The $form_field variable can sometimes be missing keys that are available in the $setting array when "MU"-plugins are used. Added a check to ensure that the keys exist in both arrays before attempting to access them, preventing potential undefined key errors.
- 
-------------------
+
 ## [1.0.3] - 2026-03-30
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "krokedil/support",
     "description": "The support library allows you to extend your plugin with logging that can be optionally toggled through your plugin settings, generate an entry in the system report from your plugin settings, and report issues to the system report.",
     "type": "library",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "authors": [
         {
             "name": "Krokedil AB",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d94c972a2a7eaa417346367a10664cc",
+    "content-hash": "1bed89b2fcd0d2c2d4160ff712c404ba",
     "packages": [],
     "packages-dev": [
         {

--- a/src/SystemReport.php
+++ b/src/SystemReport.php
@@ -189,13 +189,13 @@ class SystemReport {
 	 */
 	private function is_match( $form_field ) {
 		foreach ( $this->included_settings as $setting ) {
-			if ( isset( $setting['type'] ) && $setting['type'] === $form_field['type'] ) {
+			if ( isset( $setting['type'], $form_field['type'] ) && $setting['type'] === $form_field['type'] ) {
 				return $setting;
 			}
-			if ( isset( $setting['id'] ) && $setting['id'] === $form_field['id'] ) {
+			if ( isset( $setting['id'], $form_field['id'] ) && $setting['id'] === $form_field['id'] ) {
 				return $setting;
 			}
-			if ( isset( $setting['class'] ) && $setting['class'] === $form_field['class'] ) {
+			if ( isset( $setting['class'], $form_field['class'] ) && $setting['class'] === $form_field['class'] ) {
 				return $setting;
 			}
 		}


### PR DESCRIPTION
### Fixed

* The $form_field variable can sometimes be missing keys that are available in the $setting array when "MU"-plugins are used. Added a check to ensure that the keys exist in both arrays before attempting to access them, preventing potential undefined key errors.